### PR TITLE
Fix support for array typehinting

### DIFF
--- a/phply/phpparse.py
+++ b/phply/phpparse.py
@@ -1237,7 +1237,8 @@ def p_static_non_empty_array_pair_list_pair(p):
 
 def p_namespace_name(p):
     '''namespace_name : namespace_name NS_SEPARATOR STRING
-                      | STRING'''
+                      | STRING
+                      | ARRAY'''
     if len(p) == 4:
         p[0] = p[1] + p[2] + p[3]
     else:

--- a/phply/phpparse.py
+++ b/phply/phpparse.py
@@ -1257,11 +1257,14 @@ def p_encaps_list(p):
 
 def p_encaps_list_string(p):
     'encaps_list : encaps_list ENCAPSED_AND_WHITESPACE'
+    try:
+        p2 = p[2].decode('string_escape')
+    except ValueError:
+        p2 = p[2]
     if p[1] == '':
-        p[0] = p[2].decode('string_escape')
+        p[0] = p2
     else:
-        p[0] = ast.BinaryOp('.', p[1], p[2].decode('string_escape'),
-                            lineno=p.lineno(2))
+        p[0] = ast.BinaryOp('.', p[1], p2, lineno=p.lineno(2))
 
 def p_encaps_var(p):
     'encaps_var : VARIABLE'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -700,7 +700,7 @@ def test_magic_constants():
 
 def test_type_hinting():
     input = r"""<?
-    function foo(Foo $var1, Bar $var2=1, Quux &$var3, Corge &$var4=1) {
+    function foo(Foo $var1, Bar $var2=1, Quux &$var3, Corge &$var4=1, array &$var5=array()) {
     }
     ?>""";
     expected = [
@@ -708,7 +708,8 @@ def test_type_hinting():
             [FormalParameter('$var1', None, False, 'Foo'),
              FormalParameter('$var2', 1, False, 'Bar'),
              FormalParameter('$var3', None, True, 'Quux'),
-             FormalParameter('$var4', 1, True, 'Corge')],
+             FormalParameter('$var4', 1, True, 'Corge'),
+             FormalParameter('$var5', Array([]), True, 'array')],
             [],
             False)]
     eq_ast(input, expected)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -137,10 +137,12 @@ def test_string_unescape():
     input = r"""<?
         '\r\n\t\\\'';
         "\r\n\t\\\"";
+        "\x97\x[0-9]";
     ?>"""
     expected = [
         r"\r\n\t\'",
         "\r\n\t\\\"",
+        r"\x97\x[0-9]",
     ]
     eq_ast(input, expected)
 


### PR DESCRIPTION
`function(array $a) {}` typehinting would not work as `ARRAY` is a
reserved token of its own and gets precedence over `STRING` in
`namespace_name`, resulting in a syntax error. By adding `ARRAY` as a
variant a successful parse is attained. Tests included.